### PR TITLE
Overlap_merge.py edit (Issue3)

### DIFF
--- a/4-Assembly/Overlap_merge.py
+++ b/4-Assembly/Overlap_merge.py
@@ -66,7 +66,7 @@ def identify_overlaps(alignments):
     overlaps.columns=['Ref1_ID', 'R1_Start','R1_End','Query1_ID', 'Q1_Start','Q1_End','R1_Length','Q1_Length','Orientation1','Ref2_ID', 'R2_Start','R2_End','Query2_ID', 'Q2_Start','Q2_End','R2_Length','Q2_Length','Orientation2']
     overlaps['Overlap_Len'] = (overlaps['R2_Start'] - overlaps['R1_End']).abs()
     #overlaps['Predicted_Merge_Len'] = (overlaps['R1_Length'] + overlaps['R2_Length'] - overlaps['Overlap_Len']).abs()
-    return overlaps.sort_values('Ref1_ID').drop_duplicates(subset=['Query1_ID', 'Query2_ID'], keep='first')
+    return overlaps.sort_values('Ref1_ID').drop_duplicates(subset=['Query1_ID', 'Query2_ID'], keep='first').sort_index().reset_index(drop=True)
 
 #map sequence ID with key
 def map_key(overlaps,keys):
@@ -129,7 +129,9 @@ def ref_query(overlaps_key):
             overlaps_key.loc[i,'Query_Len_final'] = overlaps_key_cluster.loc[i,'Query_Len']        
             overlaps_key.loc[i,'Ref_Sequence_ID_final'] = overlaps_key_cluster.loc[i,'Ref_Sequence_ID']
             overlaps_key.loc[i,'Ref_Len_final'] = overlaps_key_cluster.loc[i,'Ref_Len']
+            overlaps_key_cluster = overlaps_key[overlaps_key['cluster']==x]
             for i in overlaps_key_cluster.index[1:]:
+                overlaps_key_cluster = overlaps_key[overlaps_key['cluster']==x]
                 overlaps_key.loc[i,'Output_Sequence_ID'] = overlaps_key.loc[i-1,'Output_Sequence_ID'].split('_map')[0] +'_merge'+ str(i+1) +'_map' + str(overlaps_key.loc[i,'Ref1_ID'])
     #            overlaps_key.loc[i,'Output_Predicted_Len'] = abs(overlaps_key.loc[i,'Ref_Len'] + overlaps_key.loc[i,'Query_Len_final'] - overlaps_key.loc[i,'Overlap_Len'])
                 if overlaps_key_cluster.loc[i,'Ref_Len'] > overlaps_key_cluster.loc[i-1,'Output_Predicted_Len']:
@@ -213,7 +215,7 @@ def output(overlaps_key,out_dir,genomepath):
         f.writelines( "%s\n" % item for item in modified_seq_input)
     with open(os.path.join(out_dir,'output_seq.txt'),'w') as f:
         for item in output_seq:
-            item_path = os.path.join(out_dir,overlap_sequence_ids,item+'.fasta')
+            item_path = os.path.join(out_dir,'*',item+'.renamed.fasta')
             f.writelines(item_path + ' ')
     #print(output_seq)
        


### PR DESCRIPTION
I recently tested updated scripts in 4-Assembly folder.
However, I failed to run the script 'Overlap_merge.py'.
After running the command below I got error messages.

python3 /opt/Ab10-Assembly/4-Assembly/Overlap_merge.py
-x /output/core_assembly/step3_merging/contig_merge/alignref/core_sup_merged_hybridassembly0_CTTAAG_0kb_0labels.xmap
-k /output/core_assembly/step3_merging/contig_merge/core_sup_merged_hybridassembly0_CTTAAG_0kb_0labels_key.txt
-o /output/core_assembly/step3_merging/contig_overlap_merge

[Error messages]
Traceback (most recent call last):
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2898, in get_loc
return self._engine.get_loc(casted_key)
File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
File "pandas/_libs/hashtable_class_helper.pxi", line 1032, in pandas._libs.hashtable.Int64HashTable.get_item
File "pandas/_libs/hashtable_class_helper.pxi", line 1039, in pandas._libs.hashtable.Int64HashTable.get_item
KeyError: 10

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/opt/Ab10-Assembly/4-Assembly/Overlap_merge_ver.2.py", line 246, in
main(xmap_file=args.xmap_file, key_file=args.key_file,out_dir=args.out_dir)
File "/opt/Ab10-Assembly/4-Assembly/Overlap_merge_ver.2.py", line 230, in main
overlaps_key=group(overlaps_key)
File "/opt/Ab10-Assembly/4-Assembly/Overlap_merge_ver.2.py", line 98, in group
if overlaps_key.loc[i,'Ref1_ID'] == overlaps_key.loc[i-1,'Ref1_ID'] and overlaps_key.loc[i,'R1_Start'] <= overlaps_key.loc[i-1,'R1_End']:
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexing.py", line 873, in getitem
return self._getitem_tuple(key)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexing.py", line 1044, in _getitem_tuple
return self._getitem_lowerdim(tup)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexing.py", line 786, in _getitem_lowerdim
section = self._getitem_axis(key, axis=i)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexing.py", line 1110, in _getitem_axis
return self._get_label(key, axis=axis)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexing.py", line 1059, in _get_label
return self.obj.xs(label, axis=axis)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/generic.py", line 3493, in xs
loc = self.index.get_loc(key)
File "/root/anaconda3/envs/Biopython_1.71/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2900, in get_loc
raise KeyError(key) from err
KeyError: 10


[correction]
Hence, I suggest fix Overlap_merge.py as shown below.
I found Overlap_merge.py works well without errors after correction.

line 69
`    return overlaps.sort_values('Ref1_ID').drop_duplicates(subset=['Query1_ID', 'Query2_ID'], keep='first')`
->
`    return overlaps.sort_values('Ref1_ID').drop_duplicates(subset=['Query1_ID', 'Query2_ID'], keep='first').sort_index().reset_index(drop=True)`
line 131-132
`            overlaps_key.loc[i,'Ref_Len_final'] = overlaps_key_cluster.loc[i,'Ref_Len']`
`            for i in overlaps_key_cluster.index[1:]:`
->
`           overlaps_key.loc[i,'Ref_Len_final'] = overlaps_key_cluster.loc[i,'Ref_Len']`
`            overlaps_key_cluster = overlaps_key[overlaps_key['cluster']==x]`
`            for i in overlaps_key_cluster.index[1:]:`
`                overlaps_key_cluster = overlaps_key[overlaps_key['cluster']==x]`

line 216
`            item_path = os.path.join(out_dir,overlap_sequence_ids,item+'.fasta')`
->
`            item_path = os.path.join(out_dir,'*',item+'.renamed.fasta')`
